### PR TITLE
Routing messages

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@ import random as rand
 from web3 import Web3
 from collections import defaultdict
 
-NUM_SHARDS = 3
+NUM_SHARDS = 6
 NUM_VALIDATORS = 18
 
 SHARD_IDS = list(range(NUM_SHARDS))
@@ -18,10 +18,11 @@ VALIDATOR_SHARD_ASSIGNMENT = {}
 SHARD_VALIDATOR_ASSIGNMENT = defaultdict(list)
 for v in VALIDATOR_NAMES:
     # TODO: Remove the +1. Put in to keep assignment the same.
-    shard = v // (NUM_VALIDATORS//len(SHARD_IDS) + 1)
+    shard = v // (NUM_VALIDATORS//len(SHARD_IDS))
     VALIDATOR_SHARD_ASSIGNMENT[v] = shard
     SHARD_VALIDATOR_ASSIGNMENT[shard].append(v)
 TTL_CONSTANT = 3
+print(SHARD_VALIDATOR_ASSIGNMENT)
 
 NUM_TRANSACTIONS = 50
 
@@ -34,11 +35,11 @@ REPORT_INTERVAL = 1
 PAUSE_LENGTH = 0.1
 
 # Instant broadcast
-FREE_INSTANT_BROADCAST = False
+FREE_INSTANT_BROADCAST = True
 
 # Validity check options
 VALIDITY_CHECKS_WARNING_OFF = True
-VALIDITY_CHECKS_OFF = True
+VALIDITY_CHECKS_OFF = False
 
 DEADBEEF = Web3.toChecksumAddress(hex(1271270613000041655817448348132275889066893754095))
 

--- a/validator.py
+++ b/validator.py
@@ -185,9 +185,10 @@ class Validator:
         newly_received_payloads = MessagesLog()
         for ID in fork_choice.keys():
             for m in newly_received_messages[ID]:
-                newly_received_payloads.add_message(ID, m)
+                if m.target_shard_ID == shard_ID:
+                    newly_received_payloads.add_message(ID, m)
 
-                if m.target_shard_ID != shard_ID:
+                else:
                     next_hop_ID = self.next_hop(prevblock, m.target_shard_ID)
                     if next_hop_ID is not None:
                         assert next_hop_ID in prevblock.child_IDs


### PR DESCRIPTION
- sources now point at genesis block instead of None if no block is known
- messages that go to shards that are not neighbors are now not ignored (they
  were implicitly ignored because we'd never assign the received_messages to
  sent_messages for pairs of shards that are not neighbors)
- computing the next hop to send the message to when the message is initially created
- reroute messages
- validate that the messages were rerouted